### PR TITLE
Reuse deprecated method setBackgroundDrawable

### DIFF
--- a/library/src/com/f2prateek/progressbutton/ProgressButton.java
+++ b/library/src/com/f2prateek/progressbutton/ProgressButton.java
@@ -138,7 +138,7 @@ public class ProgressButton extends CompoundButton {
         setChecked(a.getBoolean(R.styleable.ProgressButton_pinned, false));
         setClickable(a.getBoolean(R.styleable.ProgressButton_android_clickable, false));
         setFocusable(a.getBoolean(R.styleable.ProgressButton_android_focusable, false));
-        setBackground(a.getDrawable(R.styleable.ProgressButton_android_selectableItemBackground));
+        setBackgroundDrawable(a.getDrawable(R.styleable.ProgressButton_android_selectableItemBackground));
 
         a.recycle();
 


### PR DESCRIPTION
The init() method currently calls setBackground() which was added in api level 16. Consequence is that the widget is not available on devices prior to Jelly Bean.

I suggest to reuse the deprecated method setBackgroundDrawable().
